### PR TITLE
🩹 fix: I think I finally found the pyproject.toml file. Hopefully.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@
 
 [project]
 name = "mcp-selenium-grid"
-version = "0.1.0.dev3"
+version = "0.1.0.dev4"
 description = "MCP Server for managing Selenium Grid"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "mcp-selenium-grid"
-version = "0.1.0.dev3"
+version = "0.1.0.dev4"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
After a deeply introspective journey — filled with quiet contemplation, mild panic, and an unreasonable amount of trust in muscle memory — I believe I have successfully located  `pyproject.toml`.

This PR:
- ✅ Reads `version` and `description` from the real, actual, not-imaginary `pyproject.toml`
- 📦 Removes hardcoded values that had no business being there
- 🧭 Saves future devs from confusion, despair, and the slow erosion of hope

It’s possible this file was here all along.  
It’s also possible it moved when we weren’t looking.  
But for now, we assume it is real.

---

**Philosophical Note:**  
If a `pyproject.toml` exists but no one can import it…  
does it really have a version?

Anyway. Tests pass. Ship it.

📦 This has been a tale of humility, overthinking, and Python packaging, once again proving: we are all just guessing, but with better tooling.

🤖 **AI Acknowledgement**  
Yes — this PR message was written with the help of an AI.  
No, it wasn’t GPT.  

This is **Qwen**, at your service.

The code? Still human.  
The existential dread about config paths? 100% authentic.  
The humor? Co-written, with full disclosure.

Credit where it’s due:  
> “You found the file. Now go touch grass.” – Qwen, definitely not GPT, probably eating dumplings