### PR TITLE
🔓 feat: simplify local usage with `SERVER_AUTH_DISABLED` mode — all tests pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For Docker-based deployment, ensure Docker is running and use the Docker configu
         "--port", "8000"
       ],
       "env": {
-        "API_TOKEN": "CHANGE_ME",
+        "API_TOKEN": "SERVER_AUTH_DISABLED",
         "ALLOWED_ORIGINS": "[\"http://127.0.0.1:8000\"]",
         "DEPLOYMENT_MODE": "docker",
         "SELENIUM_GRID__USERNAME": "USER",
@@ -136,7 +136,7 @@ uvx mcp-selenium-grid helm uninstall --delete-namespace
         "--port", "8000"
       ],
       "env": {
-        "API_TOKEN": "CHANGE_ME",
+        "API_TOKEN": "SERVER_AUTH_DISABLED",
         "ALLOWED_ORIGINS": "[\"http://127.0.0.1:8000\"]",
         "DEPLOYMENT_MODE": "kubernetes",
         "SELENIUM_GRID__USERNAME": "USER",
@@ -166,7 +166,7 @@ uvx mcp-selenium-grid helm uninstall --delete-namespace
         "--rm",
         "--init",
         "-p", "8000:80",
-        "-e", "API_TOKEN=CHANGE_ME",
+        "-e", "API_TOKEN=SERVER_AUTH_DISABLED",
         "-e", "ALLOWED_ORIGINS=[\"http://127.0.0.1:8000\"]",
         "-e", "DEPLOYMENT_MODE=kubernetes", // required for docker
         "-e", "SELENIUM_GRID__USERNAME=USER",
@@ -188,6 +188,91 @@ uvx mcp-selenium-grid helm uninstall --delete-namespace
 ```
 
 > The server will be available at `http://localhost:8000` with interactive API documentation at `http://localhost:8000/docs`.
+
+### Server with auth enabled
+
+#### UVX
+
+Using default args
+
+```bash
+uvx mcp-selenium-grid server run
+```
+
+Custom args
+
+```bash
+API_TOKEN=CHANGE_ME uvx mcp-selenium-grid server run --host 127.0.0.1 --port 8000
+```
+
+#### Docker
+
+Default args
+
+```bash
+docker run -i --rm --init -p 8000:80 ghcr.io/falamarcao/mcp-selenium-grid:latest
+```
+
+Custom args
+
+```bash
+docker run -i --rm --init -p 8000:80 \
+  -e API_TOKEN=CHANGE_ME \
+  -e ALLOWED_ORIGINS='["http://127.0.0.1:8000"]' \
+  -e DEPLOYMENT_MODE=kubernetes \
+  -e SELENIUM_GRID__USERNAME=USER \
+  -e SELENIUM_GRID__PASSWORD=CHANGE_ME \
+  -e SELENIUM_GRID__VNC_PASSWORD=CHANGE_ME \
+  -e SELENIUM_GRID__VNC_VIEW_ONLY=false \
+  -e SELENIUM_GRID__MAX_BROWSER_INSTANCES=4 \
+  -e SELENIUM_GRID__SE_NODE_MAX_SESSIONS=1 \
+  -e KUBERNETES__KUBECONFIG=/kube/config-local-k3s \
+  -e KUBERNETES__CONTEXT=k3s-selenium-grid \
+  -e KUBERNETES__NAMESPACE=selenium-grid-dev \
+  -e KUBERNETES__SELENIUM_GRID_SERVICE_NAME=selenium-grid \
+  ghcr.io/falamarcao/mcp-selenium-grid:latest
+```
+
+#### MCP Server configuration (mcp.json)
+
+```json
+{
+  "mcpServers": {
+    "mcp-selenium-grid": {
+      "url": "http://localhost:8000",
+      "headers": {
+        "Authorization": "Bearer CHANGE_ME"
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "mcpServers": {
+    "mcp-selenium-grid": {
+      "url": "http://localhost:8000/mcp",
+      "headers": {
+        "Authorization": "Bearer CHANGE_ME"
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "mcpServers": {
+    "mcp-selenium-grid": {
+      "url": "http://localhost:8000/sse",
+      "headers": {
+        "Authorization": "Bearer CHANGE_ME"
+      }
+    }
+  }
+}
+```
 
 ## 🤝 Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@
 
 [project]
 name = "mcp-selenium-grid"
-version = "0.1.0.dev6"
+version = "0.1.0.dev7"
 description = "MCP Server for managing Selenium Grid"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/tests/integration/test_health_and_stats.py
+++ b/src/tests/integration/test_health_and_stats.py
@@ -4,7 +4,7 @@ import pytest
 from app.models import HealthStatus
 from fastapi import status
 from fastapi.testclient import TestClient
-from pytest import FixtureRequest
+from pytest import FixtureRequest, MonkeyPatch
 
 
 @pytest.mark.integration
@@ -32,6 +32,13 @@ def test_health_check_requires_auth(client: TestClient) -> None:
     """Test health check endpoint requires authentication."""
     response = client.get("/health")
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.integration
+def test_disabled_auth(client_disabled_auth: TestClient, monkeypatch: MonkeyPatch) -> None:
+    """Test health check endpoint without authentication when API_TOKEN is empty."""
+    response = client_disabled_auth.get("/health")
+    assert response.status_code == status.HTTP_200_OK
 
 
 @pytest.mark.integration

--- a/src/tests/unit/test_dependencies.py
+++ b/src/tests/unit/test_dependencies.py
@@ -36,6 +36,13 @@ def get_settings_override_missing() -> Settings:
 async def verify_token_override(
     credentials: HTTPAuthorizationCredentials = Depends(security),
 ) -> dict[str, str]:
+    # Check if header exists (auto_error=False)
+    if not credentials:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authenticated",
+        )
+
     if credentials.credentials != "valid_token":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/src/tests/unit/test_settings.py
+++ b/src/tests/unit/test_settings.py
@@ -40,6 +40,14 @@ def test_deployment_mode_override_by_env(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.delenv("DEPLOYMENT_MODE", raising=False)
 
 
+@pytest.mark.unit
+def test_api_token_override_by_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_TOKEN", "")
+    settings = Settings()
+    assert settings.API_TOKEN.get_secret_value() == ""
+    monkeypatch.delenv("API_TOKEN", raising=False)
+
+
 # --- YAML Loading and Special Behaviors ---
 @pytest.mark.unit
 def test_settings_loads_from_yaml(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "mcp-selenium-grid"
-version = "0.1.0.dev6"
+version = "0.1.0.dev7"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
The goal? Make it **dead simple to run the MCP server locally**

This PR introduces a lightweight, intentional bypass for local use:

### ✅ How it works
Set `API_TOKEN=SERVER_AUTH_DISABLED` → authentication is skipped, and all requests are accepted as `anonymous`.

That’s it. No API key needed. Just paste the `mcp.json` and go.

```python
if settings.API_TOKEN.get_secret_value() == "SERVER_AUTH_DISABLED":
        logger.critical(
            "API_TOKEN is disabled — skipping token verification, access granted as anonymous".upper()
        )
        return {"sub": "anonymous"}
```